### PR TITLE
Some optimization for llama2-7/13b

### DIFF
--- a/src/fastertransformer/layers/attention_layers/LlamaContextAttentionLayer.cc
+++ b/src/fastertransformer/layers/attention_layers/LlamaContextAttentionLayer.cc
@@ -140,13 +140,15 @@ void LlamaContextAttentionLayer<T>::forward(TensorMap*                output_ten
                               hidden_units_,  // k
                               qkv_buf_tmp_,
                               local_qkv_size /* n */);
-        invokeRepeatKv(qkv_buf_,
-                       qkv_buf_tmp_,
-                       local_head_num_,
-                       local_kv_head_num_,
-                       size_per_head_,
-                       m,
-                       stream_);
+        if (local_kv_head_num_ != local_head_num_) {
+            invokeRepeatKv(qkv_buf_,
+                        qkv_buf_tmp_,
+                        local_head_num_,
+                        local_kv_head_num_,
+                        size_per_head_,
+                        m,
+                        stream_);
+        }
 
         // {
         //     const int head_num = 6;
@@ -722,8 +724,12 @@ void LlamaContextAttentionLayer<T>::allocateBuffer(size_t batch_size, size_t seq
     // NOTE (perkzz): use sizeof(T) here for cutlass int8 kernels.
     const auto type_size = sizeof(T);
     qkv_buf_ = (T*)allocator_->reMalloc(qkv_buf_, type_size * 3 * batch_size * seq_len * local_hidden_units_, true);
-    size_t local_qkv_size = local_hidden_units_ + 2 * local_kv_head_num_ * size_per_head_;
-    qkv_buf_tmp_ = (T*)allocator_->reMalloc(qkv_buf_tmp_, type_size * batch_size * seq_len * local_qkv_size, true);
+    if (local_kv_head_num_ != local_head_num_) {
+        size_t local_qkv_size = local_hidden_units_ + 2 * local_kv_head_num_ * size_per_head_;
+        qkv_buf_tmp_ = (T*)allocator_->reMalloc(qkv_buf_tmp_, type_size * batch_size * seq_len * local_qkv_size, true);
+    } else {
+        qkv_buf_tmp_ = qkv_buf_;
+    }
     q_buf_2_ = (T*)allocator_->reMalloc(q_buf_2_, sizeof(T) * batch_size * seq_len * 3 * local_hidden_units_, true);
     k_buf_2_ = q_buf_2_ + batch_size * seq_len * local_hidden_units_;
     v_buf_2_ = k_buf_2_ + batch_size * seq_len * local_hidden_units_;
@@ -777,7 +783,9 @@ void LlamaContextAttentionLayer<T>::freeBuffer()
     if (is_allocate_buffer_) {
         FT_LOG_DEBUG(__PRETTY_FUNCTION__);
         allocator_->free((void**)(&qkv_buf_));
-        allocator_->free((void**)(&qkv_buf_tmp_));
+        if (local_kv_head_num_ != local_head_num_) {
+            allocator_->free((void**)(&qkv_buf_tmp_));
+        }
         allocator_->free((void**)(&q_buf_2_));
         allocator_->free((void**)(&qk_buf_));
         allocator_->free((void**)(&qkv_buf_2_));


### PR DESCRIPTION
For llama2-7/13b, since num_head=num_kv_head, there is no need to create a qkv_tmp and then repeat kv.

cc @neevaco/corvo @sfc-gh-ybsat 