### PR TITLE
TIL: fix trash output for code llama for long prompt

### DIFF
--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_128.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_128.cu
@@ -25,10 +25,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define MGQA_LAUNCH_KERNEL(                                                                                            \
-    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                \
-    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);          \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                                    \
+    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);                              \
     dim3   grid(params.num_heads, params.batch_size);                                                                  \
-    mmha::masked_groupedquery_attention_kernel<T,                                                                         \
+    cudaFuncSetAttribute(mmha::masked_groupedquery_attention_kernel<T,                                                 \
+        Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS>,                                          \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);                                                         \
+    mmha::masked_groupedquery_attention_kernel<T,                                                                      \
                                             Dh,                                                                        \
                                             Dh_MAX,                                                                    \
                                             THDS_PER_KEY,                                                              \

--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_128.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_128.cu
@@ -43,7 +43,6 @@ void mgqa_launch_kernel(const KERNEL_PARAMS_TYPE& params, const cudaStream_t& st
 {
     constexpr int  THREADS_PER_VALUE  = threads_per_value_t<T, Dh_MAX>::value;
     int            tlength            = params.timestep;
-    // printf("tlength, CROSS_ATTENTION = %d, %d\n", tlength);
     if (params.cache_indir == nullptr) {
         if (tlength < 32) {
             MGQA_LAUNCH_KERNEL(T, Dh, Dh_MAX, 4, THREADS_PER_VALUE, 64, false, stream);

--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_144.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_144.cu
@@ -25,10 +25,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define MGQA_LAUNCH_KERNEL(                                                                                            \
-    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                \
-    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);          \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                                    \
+    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);                              \
     dim3   grid(params.num_heads, params.batch_size);                                                                  \
-    mmha::masked_groupedquery_attention_kernel<T,                                                                         \
+    cudaFuncSetAttribute(mmha::masked_groupedquery_attention_kernel<T,                                                 \
+        Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS>,                                          \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);                                                         \
+    mmha::masked_groupedquery_attention_kernel<T,                                                                      \
                                             Dh,                                                                        \
                                             Dh_MAX,                                                                    \
                                             THDS_PER_KEY,                                                              \

--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_160.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_160.cu
@@ -25,10 +25,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define MGQA_LAUNCH_KERNEL(                                                                                            \
-    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                \
-    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);          \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                                    \
+    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);                              \
     dim3   grid(params.num_heads, params.batch_size);                                                                  \
-    mmha::masked_groupedquery_attention_kernel<T,                                                                         \
+    cudaFuncSetAttribute(mmha::masked_groupedquery_attention_kernel<T,                                                 \
+        Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS>,                                          \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);                                                         \
+    mmha::masked_groupedquery_attention_kernel<T,                                                                      \
                                             Dh,                                                                        \
                                             Dh_MAX,                                                                    \
                                             THDS_PER_KEY,                                                              \

--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_192.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_192.cu
@@ -25,10 +25,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define MGQA_LAUNCH_KERNEL(                                                                                            \
-    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                \
-    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);          \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                                    \
+    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);                              \
     dim3   grid(params.num_heads, params.batch_size);                                                                  \
-    mmha::masked_groupedquery_attention_kernel<T,                                                                         \
+    cudaFuncSetAttribute(mmha::masked_groupedquery_attention_kernel<T,                                                 \
+        Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS>,                                          \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);                                                         \
+    mmha::masked_groupedquery_attention_kernel<T,                                                                      \
                                             Dh,                                                                        \
                                             Dh_MAX,                                                                    \
                                             THDS_PER_KEY,                                                              \

--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_224.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_224.cu
@@ -25,10 +25,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define MGQA_LAUNCH_KERNEL(                                                                                            \
-    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                \
-    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);          \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                                    \
+    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);                              \
     dim3   grid(params.num_heads, params.batch_size);                                                                  \
-    mmha::masked_groupedquery_attention_kernel<T,                                                                         \
+    cudaFuncSetAttribute(mmha::masked_groupedquery_attention_kernel<T,                                                 \
+        Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS>,                                          \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);                                                         \
+    mmha::masked_groupedquery_attention_kernel<T,                                                                      \
                                             Dh,                                                                        \
                                             Dh_MAX,                                                                    \
                                             THDS_PER_KEY,                                                              \

--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_256.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_256.cu
@@ -25,10 +25,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define MGQA_LAUNCH_KERNEL(                                                                                            \
-    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                \
-    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);          \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                                    \
+    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);                              \
     dim3   grid(params.num_heads, params.batch_size);                                                                  \
-    mmha::masked_groupedquery_attention_kernel<T,                                                                         \
+    cudaFuncSetAttribute(mmha::masked_groupedquery_attention_kernel<T,                                                 \
+        Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS>,                                          \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);                                                         \
+    mmha::masked_groupedquery_attention_kernel<T,                                                                      \
                                             Dh,                                                                        \
                                             Dh_MAX,                                                                    \
                                             THDS_PER_KEY,                                                              \

--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_32.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_32.cu
@@ -25,10 +25,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define MGQA_LAUNCH_KERNEL(                                                                                            \
-    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                \
-    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);          \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                                    \
+    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);                              \
     dim3   grid(params.num_heads, params.batch_size);                                                                  \
-    mmha::masked_groupedquery_attention_kernel<T,                                                                         \
+    cudaFuncSetAttribute(mmha::masked_groupedquery_attention_kernel<T,                                                 \
+        Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS>,                                          \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);                                                         \
+    mmha::masked_groupedquery_attention_kernel<T,                                                                      \
                                             Dh,                                                                        \
                                             Dh_MAX,                                                                    \
                                             THDS_PER_KEY,                                                              \

--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_48.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_48.cu
@@ -25,10 +25,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define MGQA_LAUNCH_KERNEL(                                                                                            \
-    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                \
-    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);          \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                                    \
+    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);                              \
     dim3   grid(params.num_heads, params.batch_size);                                                                  \
-    mmha::masked_groupedquery_attention_kernel<T,                                                                         \
+    cudaFuncSetAttribute(mmha::masked_groupedquery_attention_kernel<T,                                                 \
+        Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS>,                                          \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);                                                         \
+    mmha::masked_groupedquery_attention_kernel<T,                                                                      \
                                             Dh,                                                                        \
                                             Dh_MAX,                                                                    \
                                             THDS_PER_KEY,                                                              \

--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_64.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_64.cu
@@ -25,10 +25,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define MGQA_LAUNCH_KERNEL(                                                                                            \
-    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                \
-    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);          \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                                    \
+    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);                              \
     dim3   grid(params.num_heads, params.batch_size);                                                                  \
-    mmha::masked_groupedquery_attention_kernel<T,                                                                         \
+    cudaFuncSetAttribute(mmha::masked_groupedquery_attention_kernel<T,                                                 \
+        Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS>,                                          \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);                                                         \
+    mmha::masked_groupedquery_attention_kernel<T,                                                                      \
                                             Dh,                                                                        \
                                             Dh_MAX,                                                                    \
                                             THDS_PER_KEY,                                                              \

--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_80.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_80.cu
@@ -25,10 +25,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define MGQA_LAUNCH_KERNEL(                                                                                            \
-    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                \
-    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);          \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                                    \
+    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);                              \
     dim3   grid(params.num_heads, params.batch_size);                                                                  \
-    mmha::masked_groupedquery_attention_kernel<T,                                                                         \
+    cudaFuncSetAttribute(mmha::masked_groupedquery_attention_kernel<T,                                                 \
+        Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS>,                                          \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);                                                         \
+    mmha::masked_groupedquery_attention_kernel<T,                                                                      \
                                             Dh,                                                                        \
                                             Dh_MAX,                                                                    \
                                             THDS_PER_KEY,                                                              \

--- a/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_96.cu
+++ b/src/fastertransformer/kernels/llama/decoder_masked_groupedquery_attention/decoder_masked_groupedquery_attention_96.cu
@@ -25,10 +25,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define MGQA_LAUNCH_KERNEL(                                                                                            \
-    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                \
-    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);          \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS, stream)                                    \
+    size_t smem_sz = mmha::smem_size_in_bytes<T>(params, THDS_PER_VALUE, THDS_PER_BLOCK);                              \
     dim3   grid(params.num_heads, params.batch_size);                                                                  \
-    mmha::masked_groupedquery_attention_kernel<T,                                                                         \
+    cudaFuncSetAttribute(mmha::masked_groupedquery_attention_kernel<T,                                                 \
+        Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, HAS_BEAMS>,                                          \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);                                                         \
+    mmha::masked_groupedquery_attention_kernel<T,                                                                      \
                                             Dh,                                                                        \
                                             Dh_MAX,                                                                    \
                                             THDS_PER_KEY,                                                              \

--- a/src/fastertransformer/triton_backend/llama/LlamaTritonModel.cc
+++ b/src/fastertransformer/triton_backend/llama/LlamaTritonModel.cc
@@ -156,13 +156,6 @@ std::unique_ptr<AbstractTransformerModelInstance> LlamaTritonModel<T>::createMod
     ft::NcclParam tensor_para   = nccl_params.first[comms_rank];
     ft::NcclParam pipeline_para = nccl_params.second[comms_rank];
 
-    ft::AttentionType attention_type = ft::getAttentionType<T>(size_per_head_,
-                                                               ft::getSMVersion(),
-                                                               true,   // remove_padding
-                                                               0,      // gpt supports any-seq-length fmha
-                                                               true,   // is_fuse
-                                                               false,  // with_relative_position_bias
-                                                               true);  // causal_mask
     auto              gpt            = std::make_unique<ft::Llama<T>>(
         ft::Llama<T>(head_num_,
                      kv_head_num_,
@@ -192,7 +185,7 @@ std::unique_ptr<AbstractTransformerModelInstance> LlamaTritonModel<T>::createMod
                      allocator.get(),
                      false,
                      cuda_device_prop_ptr.get(),
-                     attention_type,
+                     ft::AttentionType::FUSED_MHA,
                      int8_mode_,
                      custom_all_reduce_comm,
                      enable_custom_all_reduce_));

--- a/src/fastertransformer/triton_backend/llama/LlamaTritonModel.cc
+++ b/src/fastertransformer/triton_backend/llama/LlamaTritonModel.cc
@@ -156,6 +156,13 @@ std::unique_ptr<AbstractTransformerModelInstance> LlamaTritonModel<T>::createMod
     ft::NcclParam tensor_para   = nccl_params.first[comms_rank];
     ft::NcclParam pipeline_para = nccl_params.second[comms_rank];
 
+    ft::AttentionType attention_type = ft::getAttentionType<T>(size_per_head_,
+                                                               ft::getSMVersion(),
+                                                               true,   // remove_padding
+                                                               0,      // gpt supports any-seq-length fmha
+                                                               true,   // is_fuse
+                                                               false,  // with_relative_position_bias
+                                                               true);  // causal_mask
     auto              gpt            = std::make_unique<ft::Llama<T>>(
         ft::Llama<T>(head_num_,
                      kv_head_num_,
@@ -185,7 +192,7 @@ std::unique_ptr<AbstractTransformerModelInstance> LlamaTritonModel<T>::createMod
                      allocator.get(),
                      false,
                      cuda_device_prop_ptr.get(),
-                     ft::AttentionType::FUSED_MHA,
+                     attention_type,
                      int8_mode_,
                      custom_all_reduce_comm,
                      enable_custom_all_reduce_));


### PR DESCRIPTION
When prompt length is very long, the shared memory size grow to more than 48kb, which is the default value in cuda. We need to manually set the shared memory size.

https://leimao.github.io/blog/CUDA-Shared-Memory-Capacity/#:~:text=However%2C%20CUDA%20shared%20memory%20has,is%2048%20KB%20by%20default.

cc @sfc-gh-vichan @neevaco/corvo 